### PR TITLE
REQUIREMENT: count=n parameter support for Nightscout REST API

### DIFF
--- a/lib/FHIRClient.js
+++ b/lib/FHIRClient.js
@@ -115,7 +115,7 @@ function FHIRClient (URL, patient, bearertoken) {
       var results = await _fhirClient.search({
          resourceType: type
          , searchParams: {
-            _count: 10
+            _count: 20
             , _sort: date
             , patient: patientId
          }

--- a/lib/NSRESTService.js
+++ b/lib/NSRESTService.js
@@ -66,7 +66,7 @@ function NSRestServer (env) {
 
    NightscoutRESTServer.getAsync('/treatments', getUser, async (req, res) => {
       let token = await env.oauthProvider.getAccessTokenForUser(req.user);
-      let treatments = await Treatments.getTreatments(env.FHIRServer, req.user.sub, token);
+      let treatments = await Treatments.getTreatments(env.FHIRServer, req.user.sub, token, req.query);
       res.send(treatments);
    });
 
@@ -92,7 +92,7 @@ function NSRestServer (env) {
 
    NightscoutRESTServer.getAsync('/entries', getUser, async (req, res) => {
       let token = await env.oauthProvider.getAccessTokenForUser(req.user);
-      let entries = await Entries.getEntries(env.FHIRServer, req.user.sub, token);
+      let entries = await Entries.getEntries(env.FHIRServer, req.user.sub, token, req.query);
       res.send(entries);
    });
 

--- a/lib/nshandlers/entries.js
+++ b/lib/nshandlers/entries.js
@@ -4,12 +4,16 @@ const DataConverter = _DataConverter();
 
 function NSEntries () {
 
-   NSEntries.getEntries = async function (fhirserver, userid, token) {
+   NSEntries.getEntries = async function (fhirserver, userid, token, query) {
+
+      var count = 20;
+      if (query.count && !isNaN(query.count)) { count = Math.min(query.count, 10000); }
+      console.log('Requesting up to ' + count + ' entries');
 
       var FHIRClient = new(require('../FHIRClient'))(fhirserver, userid, token);
 
       let s = {
-         _count: 1
+         _count: count
          , _sort: 'date'
          , patient: userid
          , code: '14743-9'
@@ -19,7 +23,7 @@ function NSEntries () {
       console.log('Got Glucometer entries, count ' + records.body.total);
 
       s = {
-         _count: 1
+         _count: count
          , _sort: 'date'
          , patient: userid
          , code: '14745-4'

--- a/lib/nshandlers/treatments.js
+++ b/lib/nshandlers/treatments.js
@@ -4,13 +4,17 @@ const DataConverter = _DataConverter();
 
 function NSTreatments () {
 
-   NSTreatments.getTreatments = async function (fhirserver, userid, token) {
+   NSTreatments.getTreatments = async function (fhirserver, userid, token, query) {
+
+      var count = 20;
+      if (query.count && !isNaN(query.count)) { count = Math.min(query.count, 10000); }
+      console.log('Requesting up to ' + count + ' treatments');
 
       var FHIRClient = new(require('../FHIRClient'))(fhirserver, userid, token);
 
       // carbs
       let s = {
-         _count: 1
+         _count: count
          , _sort: 'date'
          , patient: userid
          , code: '9059-7'
@@ -21,7 +25,7 @@ function NSTreatments () {
 
       // short acting insulin
       s = {
-         _count: 1
+         _count: count
          , _sort: 'effective-time'
          , patient: userid
          , code: 'A10AC'

--- a/lib/templates/fiphr/index.js
+++ b/lib/templates/fiphr/index.js
@@ -15,8 +15,6 @@ function FIPHRDataProcessor () {
    async function loadTemplate (objectType) {
 
       let filePath = path.resolve(__dirname, objectType + '.json');
-      console.log('Loading template from: ', filePath);
-
       let template;
 
       try {


### PR DESCRIPTION
Adds support for clients loading n entries with ?count=n, when accessing the Nightscout REST API, as per Nightscout REST API spec

* Limit max entries to 10000
* Check the parameter is a number
* Change default to 20 entries (as per Nightscout behavior)
