### PR TITLE
REQUIREMENT: support full URL scheme for Nightscout REST API endpoints

### DIFF
--- a/lib/NSRESTService.js
+++ b/lib/NSRESTService.js
@@ -64,7 +64,7 @@ function NSRestServer (env) {
       }
    }
 
-   NightscoutRESTServer.getAsync('/treatments', getUser, async (req, res) => {
+   NightscoutRESTServer.getAsync('/treatments*', getUser, async (req, res) => {
       let token = await env.oauthProvider.getAccessTokenForUser(req.user);
       let treatments = await Treatments.getTreatments(env.FHIRServer, req.user.sub, token, req.query);
       res.send(treatments);
@@ -90,7 +90,7 @@ function NSRestServer (env) {
    });
 
 
-   NightscoutRESTServer.getAsync('/entries', getUser, async (req, res) => {
+   NightscoutRESTServer.getAsync('/entries*', getUser, async (req, res) => {
       let token = await env.oauthProvider.getAccessTokenForUser(req.user);
       let entries = await Entries.getEntries(env.FHIRServer, req.user.sub, token, req.query);
       res.send(entries);


### PR DESCRIPTION
The API did not support calls that had appended ".json" to the REST URL