### PR TITLE
BUGFIX: use observation value for UUID calculation

### DIFF
--- a/lib/FHIRClient.js
+++ b/lib/FHIRClient.js
@@ -165,6 +165,7 @@ function FHIRClient (URL, patient, bearertoken) {
          }
          if (results.status == 200) {
             uploadResults.skipped += 1;
+            console.log('Record skipped: ' + results.location);
          }
 
       } catch (error) {

--- a/lib/TidepoolRESTService.js
+++ b/lib/TidepoolRESTService.js
@@ -220,7 +220,9 @@ function TidepoolRESTService (runtimeEnv) {
             success = false;
             console.log(error);
          }
-         console.log('Converted and uploaded records: ' + JSON.stringify(uploadResults.created));
+         console.log('Records created: ' + JSON.stringify(uploadResults.created));
+         console.log('Records skipped: ' + JSON.stringify(uploadResults.skipped));
+         console.log('Errors: ' + JSON.stringify(uploadResults.errors));
 
          if (!success || uploadResults.errors > 0) {
             console.log('Upload failed');

--- a/lib/templates/fiphr/index.js
+++ b/lib/templates/fiphr/index.js
@@ -139,7 +139,7 @@ function FIPHRDataProcessor () {
 
       let id = entry.type + ':' + entry.patientId + ':' + entry.deviceId + ':' + entry.time_fhir;
 
-      if (entry.type == 'Observation') {
+      if (entry.value) {
          id = id + ':' + entry.value; // It is possible for a device to have multuple records with the same timestamp
       }
 


### PR DESCRIPTION
Turns out the previous change didn't actually work, the earlier bug just didn't trigger due to other reasons