### PR TITLE
BUGFIX: Add back support for /auth/kanta URL for backward compatibility

### DIFF
--- a/nsfi.js
+++ b/nsfi.js
@@ -144,7 +144,7 @@ app.get('/logout', (req, res) => {
 /// Kanta authentication
 
 app.use('/fiphr', env.oauthProvider);
-
+app.use('/auth/kanta', env.oauthProvider);
 ////
 
 let nsrest = NSRestService(env);


### PR DESCRIPTION
As part of refactoring the code, the URL to initiate Kanta authentication was changed. This PR adds back support for the old URL entry point.