### PR TITLE
BUGFIX: Change how the openid-client is instantiated

### DIFF
--- a/lib/oauthproviders/FIPHR.js
+++ b/lib/oauthproviders/FIPHR.js
@@ -59,7 +59,7 @@ function FIPHR (env) {
    const tokenUrl = new URL(OauthTokenURL);
    const authorizeUrl = new URL(OAuthAuthorizationURL);
 
-   const { Issuer } = require('openid-client');
+   const { Issuer, custom } = require('openid-client');
 
    const urli = `${tokenUrl.protocol}//${tokenUrl.host}`;
 
@@ -84,9 +84,12 @@ function FIPHR (env) {
       var privateKey = fs.readFileSync(authKey, 'utf8');
       var certificate = fs.readFileSync(authCert, 'utf8');
 
+      console.log('Usign private key', privateKey);
+      console.log('Usign certificate key', certificate);
+
       //const { custom } = require('openid-client');
 
-      client[Issuer.http_options] = function (options) {
+      client[custom.http_options] = function (options) {
          // see https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
          // key, cert, ca, ciphers, clientCertEngine, crl, dhparam, ecdhCurve, honorCipherOrder, passphrase
          // pfx, rejectUnauthorized, secureOptions, secureProtocol, servername, sessionIdContext
@@ -140,7 +143,6 @@ function FIPHR (env) {
          let token;
          console.log('OauthCallbackURL', OauthCallbackURL);
          console.log('req.query', req.query);
-
          console.log('client', client);
 
          try {


### PR DESCRIPTION
Change needed to ensure the client reads in the HTTPS key and cert