### PR TITLE
BUGFIX: Fix a bug in loading certificates into the FHIR client

### DIFF
--- a/lib/FHIRClient.js
+++ b/lib/FHIRClient.js
@@ -11,7 +11,7 @@ function FHIRClient (URL, patient, bearertoken, env) {
 
    let options = { baseUrl: URL };
 
-   if (env && env.cert) {
+   if (env && env.https_certificate) {
       options.cert = env.https_certificate;
       options.key = env.https_privateKey;
    }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5683,8 +5683,8 @@
       }
     },
     "fhir-kit-client": {
-      "version": "git://github.com/sulkaharo/fhir-kit-client.git#9de6c2c95db3d0604ca41dba95ab895211fdaf8c",
-      "from": "git://github.com/sulkaharo/fhir-kit-client.git#return_full_response_v3",
+      "version": "git://github.com/sulkaharo/fhir-kit-client.git#8d761c63a299700373c39562b4edcef589cc5dbb",
+      "from": "git://github.com/sulkaharo/fhir-kit-client.git#https_cert_support",
       "requires": {
         "debug": "^3.1.0",
         "es6-promise": "^4.2.4",
@@ -15106,11 +15106,12 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.4.0.tgz",
-      "integrity": "sha512-Werid2I41/tJTqOGPJ3cC3vwrIh/8ZupBQbp7BSsqXzr+pTin3aMJ/EZb8UEuk7ZO3VqQFvq2qck/ihc6wqIdw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.5.0.tgz",
+      "integrity": "sha512-TYC4hDjZSvVxLMEucDMySkuAS9UIzSbAiYGyA9GWCjLKB8fQpviFbjd20fD7uejCDxZS+ftSdBKE6DS+xucJFg==",
       "requires": {
         "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
     },
@@ -17319,6 +17320,11 @@
           }
         }
       }
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "split-string": {
       "version": "3.1.0",


### PR DESCRIPTION
Fix the TLS certificate loading (only noticed to not work in production due to other IP numbers not being available for testing).