### PR TITLE
REQUIREMENT: Fix nutrition profile encoding

### DIFF
--- a/local_modules/sensotrend-converter/src/templates/fiphr/import_carbs.json
+++ b/local_modules/sensotrend-converter/src/templates/fiphr/import_carbs.json
@@ -17,7 +17,7 @@
                 {
                     "system": "http://phr.kanta.fi/CodeSystem/fiphr-cs-observationcategory",
                     "code": "nutrition",
-                    "display": "Ravintosisältö"
+                    "display": "Ravitsemus"
                 }
             ]
         }


### PR DESCRIPTION
Requirement from Kela: The nutrition category display coding should say "Ravitsemus", not "Ravintosisältö"