### PR TITLE
REFACTOR: Use the official fhir-kit-client

### DIFF
--- a/lib/FHIRClient.js
+++ b/lib/FHIRClient.js
@@ -9,11 +9,15 @@ function FHIRClient (URL, { patient, bearertoken, env } = {}) {
 
    logger.info('Client Init on URL ' + URL + ' and patient ' + patient);
 
-   let options = { baseUrl: URL };
+   let options = {
+      baseUrl: URL
+   };
 
    if (env && env.https_certificate) {
-      options.cert = env.https_certificate;
-      options.key = env.https_privateKey;
+      let requestOptions = {};
+      requestOptions.cert = env.https_certificate;
+      requestOptions.key = env.https_privateKey;
+      options.requestOptions = requestOptions;
    }
 
    const _fhirClient = new Client(options);
@@ -147,12 +151,13 @@ function FHIRClient (URL, { patient, bearertoken, env } = {}) {
             }
          });
 
-         const status = results[Client.StatusCode];
+         const response = Client.responseFor(results);
+         const status = response.statusCode;
 
          if (status == 201) {
-            if (results[Client.Location]) {
+            if (response.headers && response.headers.location) {
                const codes = getCodes(record);
-               logger.info(record.resourceType + ' identifier ' + record.identifier[0].value + ' created at ' + results[Client.Location]);
+               logger.info(record.resourceType + ' identifier ' + record.identifier[0].value + ' created at ' + response.headers.location);
             }
             uploadResults.created += 1;
             uploadResults.records.push(results);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5609,8 +5609,9 @@
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "fhir-kit-client": {
-      "version": "git://github.com/sulkaharo/fhir-kit-client.git#e2552bc254a09f9013667692809abc6760b2032f",
-      "from": "git://github.com/sulkaharo/fhir-kit-client.git#backward-compatible",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fhir-kit-client/-/fhir-kit-client-1.3.0.tgz",
+      "integrity": "sha512-7vugpYD+uNDEIWcYKuD7kInnmsPye2q5iJH2y0ZZq4k5Ta+40zqyC/hC8VBqeP8Eww6yyxy7+zuuljMOLUk63g==",
       "requires": {
         "debug": "^3.1.0",
         "es6-promise": "^4.2.4",
@@ -5621,9 +5622,9 @@
       },
       "dependencies": {
         "es6-promise": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-          "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         }
       }
     },
@@ -13251,9 +13252,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.5.0.tgz",
-      "integrity": "sha512-TYC4hDjZSvVxLMEucDMySkuAS9UIzSbAiYGyA9GWCjLKB8fQpviFbjd20fD7uejCDxZS+ftSdBKE6DS+xucJFg==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.1.tgz",
+      "integrity": "sha512-g6y0Lbq10a5pPQpjlFuojfMfV1Pd2Jw9h75ypiYPPia3Gcq2rgkKiIwbkS6JxH7c5f5u/B/sB+d13PU+g1eu4Q==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "^4.17.1",
     "express-cls-hooked": "^0.3.8",
     "express-session": "^1.16.1",
-    "fhir-kit-client": "git://github.com/sulkaharo/fhir-kit-client.git#backward-compatible",
+    "fhir-kit-client": "1.3.0",
     "forever": "^1.0.0",
     "formik": "^1.5.7",
     "fs-extra": "^7.0.1",


### PR DESCRIPTION
The official fhir-kit-client now supports access to response headers and TLS certificate and key files, so we can stop using a forked version